### PR TITLE
Support delete objects

### DIFF
--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -252,7 +252,7 @@ module FakeS3
       object
     end
 
-    def delete_object(bucket,object_name,request)
+    def delete_object(bucket,object_name)
       begin
         filename = File.join(@root,bucket.name,object_name)
         FileUtils.rm_rf(filename)

--- a/lib/fakes3/version.rb
+++ b/lib/fakes3/version.rb
@@ -1,3 +1,3 @@
 module FakeS3
-  VERSION = "1.0.0-9"
+  VERSION = "1.0.0-10"
 end

--- a/lib/fakes3/xml_adapter.rb
+++ b/lib/fakes3/xml_adapter.rb
@@ -218,5 +218,37 @@ module FakeS3
       }
       output
     end
+
+    # <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    #   <Deleted>
+    #     <Key>sample1.txt</Key>
+    #   </Deleted>
+    #   <Error>
+    #     <Key>sample2.txt</Key>
+    #     <Code>AccessDenied</Code>
+    #     <Message>Access Denied</Message>
+    #   </Error>
+    # </DeleteResult>
+    def self.delete_objects_result(result_objects)
+      output = ""
+      xml = Builder::XmlMarkup.new(:target => output)
+      xml.instruct! :xml, :version=>"1.0", :encoding=>"UTF-8"
+      xml.DeleteResult(:xmlns => "http://s3.amazonaws.com/doc/2006-03-01/") { |result|
+        result_objects.each do |res|
+          if not res[:code].nil?
+            result.Error { |error|
+              error.Key(res[:key])
+              error.Code(res[:code])
+              error.Message(res[:message])
+            }
+          else
+            result.Deleted { |deleted|
+              deleted.Key(res[:key])
+            }
+          end
+        end
+      }
+      output
+    end
   end
 end


### PR DESCRIPTION
Support DeleteObjects operation

This operation allows to delete multiple objects from a bucket using a
single HTTP request. For more details read
https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html

The changes is based on https://github.com/jubos/fake-s3/pull/117/files.
I've just simplified it a bit and omitted the tests.